### PR TITLE
Fix CI: pin Astro build to Node 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Build with Astro
         uses: withastro/action@v3
+        with:
+          node-version: 22
 
   deploy:
     needs: build


### PR DESCRIPTION
## Problem
The Pages deploy failed after the portfolio rebuild merge ([run 27488866804](https://github.com/stimothy/stimothy.github.io/actions/runs/27488866804/job/81250116225)):

```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```

Astro 6 requires Node ≥22.12.0, but `withastro/action@v3` defaults to Node 20.

## Fix
Pin the build to Node 22 via the action's `node-version` input.

## Test Plan
- [x] Workflow YAML validates
- [ ] Deploy workflow succeeds on this branch / after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)