### PR TITLE
Sticky header and push-to-bottom footer

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -24,7 +24,14 @@ const links = [
 </nav>
 
 <style>
-  .site-nav { border-bottom: 1px solid var(--border); padding: 1rem 0; }
+  .site-nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 0;
+    background: var(--bg);
+  }
   .nav-inner { display: flex; align-items: center; justify-content: space-between; }
   .brand { display: inline-flex; align-items: center; }
   .logo { display: block; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,10 @@ html { color-scheme: light dark; }
 
 body {
   margin: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-body);
@@ -68,7 +72,7 @@ a:hover { text-decoration: underline; }
   background: var(--surface);
 }
 
-main { padding: 3rem 0 4rem; }
+main { padding: 3rem 0 4rem; flex: 1 0 auto; }
 
 pre {
   background: var(--code-bg);


### PR DESCRIPTION
## Summary
- **Header is now sticky** to the top of the viewport (solid background, raised z-index) so navigation stays in view while scrolling.
- **Footer pushes to the bottom**: the body is a min-height flex column with `main` growing to fill, so the footer pins to the bottom of the viewport on short pages and scrolls away normally on long pages (posts).
- Uses `100dvh` (with `100vh` fallback) for correct mobile viewport height.

## Test Plan
- [x] `npm run build` — succeeds; styles present across all pages
- [x] `npx astro check` — 0 errors
- [ ] After deploy: header stays put while scrolling; footer sits at the bottom on a short page (e.g. Projects) and scrolls normally on a long post

🤖 Generated with [Claude Code](https://claude.com/claude-code)