### PR TITLE
Revamp About page from draft; document drafts workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,17 @@ Note on `astro check`: expect **0 errors / 0 warnings** but a number of *hints* 
 
 - **Layout composition.** `BaseLayout.astro` (head, `Nav`, `Footer`, slot) wraps every page; `PostLayout.astro` wraps `BaseLayout` for both writing posts and project detail pages (shared article styling).
 
+## Content drafts workflow (`drafts/`)
+
+The `drafts/` folder is Steven's scratchpad — rough, unpolished, thrown-together notes he writes just to get his thoughts out. He hands these to Claude as **source material** for real site content (About copy, blog posts, project write-ups). Treat a draft as raw input, not finished prose: pull out the facts and intent, then write them up properly in Steven's voice and the site's tone. Don't invent facts that aren't in the draft (existing real facts already on the site are fine to retain).
+
+**Required workflow for every draft — do not skip a step:**
+1. Use the draft to create or update the real page/content.
+2. **Stop and let Steven review the generated page. Do NOT delete the draft yet.**
+3. Only after Steven approves, delete the source draft file.
+
+Never delete a draft before Steven has reviewed the content it produced.
+
 ## Deployment
 
 `.github/workflows/deploy.yml` builds with `withastro/action` and deploys to GitHub Pages via `actions/deploy-pages` on every push to `master`. The custom domain ships via `public/CNAME` (copied into `dist/` at build). **One-time manual step:** the repo's Settings → Pages → Source must be set to "GitHub Actions".

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,23 +4,39 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 <BaseLayout title="About — Steven Timothy">
   <h1>About</h1>
   <p>
-    I'm Steven Timothy, a lead software engineer focused on software architecture —
-    designing systems that scale, stay understandable, and survive failure. I care
-    about clear boundaries, well-defined interfaces, and building things a team can
-    reason about.
-  </p>
-  <p>
+    I'm Steven Timothy — a lead software engineer at NiCE, where I've been since 2023.
     I hold an MS in Computer Science from the University of Utah and a BS in Computer
-    Science from Utah State University. Over my career I've worked across the full
-    stack and grown into technical leadership, where most of my attention goes to
-    architecture: how the pieces fit together, where the seams should be, and how to
-    keep a system healthy as it grows.
+    Science (with a minor in Spanish) from Utah State University. These days most of my
+    energy goes toward software architecture: how systems are shaped, why they're built
+    the way they are, and how to keep them healthy as they grow.
   </p>
+
+  <h2>What drives me</h2>
   <p>
-    This site is where I write about that work — engineering standards I believe in,
-    architecture ideas I want to explore, and the occasional thing I just find
-    interesting. If any of it helps you, that's the point.
+    I love to problem-solve. To me, software is a puzzle — figuring out how the pieces
+    fit, understanding how a system works and the reasoning behind its architecture, and
+    then tracking down and fixing whatever's broken. I care a lot about clean code;
+    there's a particular comfort in being able to drop into a codebase and feel at home.
+    Lately I've been getting into agentic AI and everything it opens up for developers and
+    architects — it's reshaping how I think about building software.
   </p>
+
+  <h2>Where I'm headed</h2>
+  <p>
+    My goal is to grow into a software architect. It fits naturally with what already gets
+    me up in the morning: I want to take a set of requirements — or an existing system —
+    and design something that doesn't just meet the requirements, but can scale and survive
+    in the world today.
+  </p>
+
+  <h2>Outside of work</h2>
+  <p>
+    Most of my time goes to my wife and our three boys. I'm a strategy-game person — I love
+    Magic: The Gathering, and getting friends together for a game of Commander. I'm happiest
+    outdoors, away from the noise of the city. And I'm drawn to medieval settings, dragons
+    and knights, and sci-fi — with a deep love of space and astronomy.
+  </p>
+
   <p class="muted">
     Find me on <a href="https://github.com/stimothy">GitHub</a> and
     <a href="https://www.linkedin.com/in/steventimothy">LinkedIn</a>.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -31,8 +31,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 
   <h2>Outside of work</h2>
   <p>
-    Most of my time goes to my wife and our three boys. I'm a strategy-game person — I love
-    Magic: The Gathering, and getting friends together for a game of Commander. I'm happiest
+    Most of my time goes to my wife and our three boys. I'm a strategy-game person — I'll
+    happily play almost any board or card game with real strategy to it. Magic: The Gathering
+    is a favorite, especially getting friends together for a game of Commander. I'm happiest
     outdoors, away from the noise of the city. And I'm drawn to medieval settings, dragons
     and knights, and sci-fi — with a deep love of space and astronomy.
   </p>


### PR DESCRIPTION
## Summary
- Rewrote the **About page** from `drafts/about-me.md`: lead engineer at NiCE (since 2023), MS/BS in CS (minor in Spanish), what drives me (problem-solving, architecture, clean code, agentic AI), the goal of becoming a software architect, and life outside work (family, Magic: The Gathering / Commander, the outdoors, medieval/sci-fi, astronomy). Organized under "What drives me / Where I'm headed / Outside of work" subheads.
- Added a **`drafts/` workflow** section to `CLAUDE.md`: drafts are Steven's scratchpad source material → use them to write the real page → **Steven reviews** → only then delete the draft.

## Note
- **The draft file is intentionally NOT deleted.** Per the documented workflow, Steven reviews the new About page first; I'll remove `drafts/about-me.md` after approval.
- Retained the university names (real facts already on the prior site); everything else comes from the draft.

## Test Plan
- [x] `npm run build` — succeeds
- [x] `npx astro check` — 0 errors
- [ ] Steven reviews the new About page wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)