### PR TITLE
Redesign: multi-section landing layout (espresso + amber)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-portfolio-layout-redesign.md
+++ b/docs/superpowers/plans/2026-06-14-portfolio-layout-redesign.md
@@ -1,0 +1,718 @@
+# Portfolio Layout Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the portfolio into a busy, multi-section landing layout rendered in the existing espresso+amber theme (serif headings, ST monogram), keeping both light/dark themes and staying mobile-friendly.
+
+**Architecture:** Presentation-layer only. Add two shared CSS primitives to `global.css` (wide container, buttons, card, section rule). `BaseLayout` gains `wide`/`bleed` props so most chrome widens to ~1120px while article body text keeps a 720px reading column. The home page becomes a full-bleed hero + featured-work grid + about/latest-writing split. Content collections, Zod schemas, `getCollection`/`render`, and the theme-resolution logic (`theme.ts`, inline anti-flash script) are untouched.
+
+**Tech Stack:** Astro 6, content collections, plain CSS custom properties (no framework). `astro:assets` `<Image>` for the portrait.
+
+**Note on TDD:** This is a CSS/markup redesign — there is no behavioral unit to test, so per-task verification is `npx astro check` (0 errors/0 warnings; the `'z' is deprecated` *hints* are expected and ignored) plus a final visual pass. Do **not** invent brittle unit tests for styling. The existing `theme.ts` tests must stay green (`npm test`) because that logic does not change.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-portfolio-layout-redesign-design.md`
+
+**Branch:** `redesign/portfolio-landing-layout` (already created off `master`; never commit to `master`).
+
+---
+
+## File map
+
+- **Modify** `src/styles/global.css` — add layout primitives (Task 1).
+- **Modify** `src/layouts/BaseLayout.astro` — `wide`/`bleed` props (Task 2).
+- **Modify** `src/components/Nav.astro` — widen + translucent blur (Task 3).
+- **Modify** `src/components/Footer.astro` — widen (Task 3).
+- **Modify** `src/components/ProjectCard.astro` — thumbnail card + "Read more →" (Task 4).
+- **Modify** `src/components/PostCard.astro` — card style for grid (Task 5).
+- **Rewrite** `src/pages/index.astro` — home landing (Task 6).
+- **Modify** `src/pages/writing/index.astro` — wide + card grid (Task 7).
+- **Modify** `src/pages/projects/index.astro` — wide + grid (Task 8).
+- **Modify** `src/pages/about.astro` — section rule, stays narrow (Task 9).
+- **Modify** `src/layouts/PostLayout.astro` — section rule, stays narrow (Task 9).
+- Final verification (Task 10).
+
+---
+
+## Task 1: Shared CSS primitives
+
+**Files:**
+- Modify: `src/styles/global.css` (append after existing rules)
+
+- [ ] **Step 1: Append the primitives**
+
+Add to the end of `src/styles/global.css`:
+
+```css
+/* ---- Layout primitives (redesign) ---- */
+.container-wide { max-width: 1120px; margin: 0 auto; padding: 0 var(--space); }
+
+main.bleed { padding: 0; }
+
+.btn {
+  display: inline-block;
+  padding: 0.7rem 1.4rem;
+  border-radius: 10px;
+  font-family: var(--font-body);
+  font-size: 0.98rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.btn:hover { text-decoration: none; }
+.btn-primary { background: var(--accent); color: var(--bg); }
+.btn-primary:hover { filter: brightness(1.06); }
+.btn-ghost { background: transparent; color: var(--text); border-color: var(--border); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+.card {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  color: var(--text);
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+.card:hover { transform: translateY(-3px); border-color: var(--accent); text-decoration: none; }
+
+.section-rule { display: inline-block; width: 46px; height: 3px; background: var(--accent); border-radius: 2px; margin-bottom: 1.2rem; }
+```
+
+Rationale: `.btn-primary` uses `color: var(--bg)` so the text is dark-on-amber in dark theme and light-on-amber in light theme automatically — token-driven, both themes correct.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings` (deprecation *hints* on `'z'` are expected, ignore them).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/styles/global.css
+git commit -m "Add layout primitives: wide container, buttons, card, section rule
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: BaseLayout wide/bleed props
+
+**Files:**
+- Modify: `src/layouts/BaseLayout.astro`
+
+- [ ] **Step 1: Add props and conditional container**
+
+Replace the frontmatter `interface Props` / destructure block and the `<main>` block.
+
+Change the frontmatter to:
+
+```astro
+interface Props {
+  title: string;
+  description?: string;
+  wide?: boolean;
+  bleed?: boolean;
+}
+const {
+  title,
+  description = 'Lead software engineer writing about how systems are built.',
+  wide = false,
+  bleed = false,
+} = Astro.props;
+```
+
+Change the `<main>` block (currently lines 35-39) to:
+
+```astro
+    <main class:list={[{ bleed }]}>
+      {bleed ? (
+        <slot />
+      ) : (
+        <div class={wide ? 'container-wide' : 'container'}><slot /></div>
+      )}
+    </main>
+```
+
+Leave `<head>`, the inline theme script, `<Nav />`, and `<Footer />` exactly as they are.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings` (ignore `'z'` hints).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/layouts/BaseLayout.astro
+git commit -m "BaseLayout: add wide and bleed container modes
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Widen nav + footer chrome
+
+**Files:**
+- Modify: `src/components/Nav.astro`
+- Modify: `src/components/Footer.astro`
+
+- [ ] **Step 1: Widen and reskin the nav**
+
+In `src/components/Nav.astro`, change the wrapper class on line 11 from `container nav-inner` to `container-wide nav-inner`:
+
+```astro
+  <div class="container-wide nav-inner">
+```
+
+Then replace the `.site-nav` rule in the `<style>` block with a translucent, blurred version (token-driven so both themes work):
+
+```css
+  .site-nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 0;
+    background: color-mix(in srgb, var(--bg) 85%, transparent);
+    backdrop-filter: blur(8px);
+  }
+```
+
+Leave the logo, links array, and other styles unchanged.
+
+- [ ] **Step 2: Widen the footer**
+
+In `src/components/Footer.astro`, change line 9 wrapper class from `container footer-inner` to `container-wide footer-inner`:
+
+```astro
+  <div class="container-wide footer-inner">
+```
+
+No other footer changes.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Nav.astro src/components/Footer.astro
+git commit -m "Widen nav/footer to wide container; translucent blurred nav
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: ProjectCard — thumbnail card
+
+**Files:**
+- Modify: `src/components/ProjectCard.astro` (full replacement)
+
+- [ ] **Step 1: Replace the component**
+
+Replace the entire contents of `src/components/ProjectCard.astro` with:
+
+```astro
+---
+interface Props {
+  href: string;
+  title: string;
+  summary: string;
+  tags: string[];
+}
+const { href, title, summary, tags } = Astro.props;
+---
+<a class="card project-card" href={href}>
+  <div class="thumb" aria-hidden="true"></div>
+  <div class="card-body">
+    <h3>{title}</h3>
+    <p class="summary">{summary}</p>
+    <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>
+    <span class="more accent">Read more →</span>
+  </div>
+</a>
+
+<style>
+  .project-card { color: var(--text); }
+  .thumb { height: 140px; position: relative; background: linear-gradient(135deg, var(--accent-soft), var(--code-bg)); }
+  .thumb::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(300px 120px at 30% 10%, color-mix(in srgb, var(--accent) 18%, transparent), transparent);
+  }
+  .card-body { padding: 1.1rem 1.2rem 1.3rem; }
+  .card-body h3 { margin: 0 0 0.4rem; font-size: 1.15rem; }
+  .summary { margin: 0 0 0.9rem; color: var(--muted); font-size: 0.92rem; }
+  .tags { margin-bottom: 0.8rem; }
+  .more { font-size: 0.9rem; font-weight: 600; }
+</style>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ProjectCard.astro
+git commit -m "ProjectCard: thumbnail card with Read more affordance
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: PostCard — card style for grid
+
+**Files:**
+- Modify: `src/components/PostCard.astro` (full replacement)
+
+- [ ] **Step 1: Replace the component**
+
+Replace the entire contents of `src/components/PostCard.astro` with:
+
+```astro
+---
+interface Props {
+  href: string;
+  title: string;
+  date: Date;
+  summary: string;
+  tags: string[];
+}
+const { href, title, date, summary, tags } = Astro.props;
+const dateStr = date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+---
+<a class="card post-card" href={href}>
+  <div class="card-body">
+    <p class="muted mono date">{dateStr}</p>
+    <h3>{title}</h3>
+    <p class="summary">{summary}</p>
+    <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>
+    <span class="more accent">Read more →</span>
+  </div>
+</a>
+
+<style>
+  .post-card { color: var(--text); }
+  .card-body { padding: 1.3rem 1.4rem 1.4rem; }
+  .date { font-size: 0.78rem; margin: 0 0 0.5rem; }
+  .post-card h3 { margin: 0 0 0.4rem; font-size: 1.2rem; }
+  .summary { margin: 0 0 0.9rem; color: var(--muted); font-size: 0.92rem; }
+  .tags { margin-bottom: 0.8rem; }
+  .more { font-size: 0.9rem; font-weight: 600; }
+</style>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/PostCard.astro
+git commit -m "PostCard: card style for grid listing
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Home landing page
+
+**Files:**
+- Rewrite: `src/pages/index.astro` (full replacement)
+
+- [ ] **Step 1: Replace the page**
+
+Replace the entire contents of `src/pages/index.astro` with:
+
+```astro
+---
+import { getCollection } from 'astro:content';
+import { Image } from 'astro:assets';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import ProjectCard from '../components/ProjectCard.astro';
+import portrait from '../assets/portrait.jpg';
+
+const latestPosts = (await getCollection('writing', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 2);
+
+const featured = (await getCollection('projects', ({ data }) => !data.draft && data.featured))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 2);
+
+const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+---
+<BaseLayout title="Steven Timothy — Lead Software Engineer" bleed>
+  <section class="hero">
+    <div class="container-wide hero-grid">
+      <div class="hero-text">
+        <h1>Lead Software Engineer<br />&amp; Future Architect</h1>
+        <p class="role">Building reliable systems — and writing about how they're designed. <span class="mono accent">// systems &amp; architecture</span></p>
+        <div class="cta">
+          <a class="btn btn-primary" href="/projects">View my work</a>
+          <a class="btn btn-ghost" href="mailto:steven.timothy265@gmail.com">Get in touch</a>
+        </div>
+        <div class="chips">
+          <span class="chip">software architecture</span>
+          <span class="chip">distributed systems</span>
+          <span class="chip">platform</span>
+        </div>
+      </div>
+      <div class="portrait-wrap">
+        <div class="codebg" aria-hidden="true"><pre>export class Service {
+  async handle(req) {
+    const ctx = build(req);
+    return pipeline(ctx);
+  }
+}
+function pipeline(ctx) {
+  for (const stage of stages)
+    ctx = stage(ctx);
+}</pre></div>
+        <Image src={portrait} alt="Steven Timothy" width={360} height={450} loading="eager" class="portrait-img" />
+      </div>
+    </div>
+  </section>
+
+  {featured.length > 0 && (
+    <section class="container-wide block">
+      <span class="section-rule"></span>
+      <h2>Featured work</h2>
+      <p class="lead muted">A few projects that show how I think about systems.</p>
+      <div class="grid">
+        {featured.map((p) => (
+          <ProjectCard href={`/projects/${p.id}`} title={p.data.title} summary={p.data.summary} tags={p.data.tags} />
+        ))}
+      </div>
+    </section>
+  )}
+
+  <section class="container-wide block">
+    <div class="split">
+      <div>
+        <span class="section-rule"></span>
+        <h2>About</h2>
+        <p class="muted">Lead software engineer focused on software architecture — how systems are shaped, why they're built the way they are, and how to keep them healthy as they grow.</p>
+        <p><a class="accent" href="/about">More about me →</a></p>
+      </div>
+      {latestPosts.length > 0 && (
+        <div>
+          <span class="section-rule"></span>
+          <h2>Latest writing</h2>
+          {latestPosts.map((p) => (
+            <a class="post-row" href={`/writing/${p.id}`}>
+              <span class="date muted mono">{fmt(p.data.date)}</span>
+              <span class="post-title">{p.data.title}</span>
+            </a>
+          ))}
+          <p style="margin-top:1rem"><a class="accent" href="/writing">All writing →</a></p>
+        </div>
+      )}
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  .hero {
+    border-bottom: 1px solid var(--border);
+    background: radial-gradient(900px 380px at 78% 20%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 60%);
+  }
+  .hero-grid { display: grid; grid-template-columns: 1.05fr 0.85fr; gap: 3rem; align-items: center; padding: 4rem 0 3.5rem; }
+  .hero-text h1 { font-size: clamp(2.2rem, 5vw, 3.4rem); margin: 0 0 1rem; }
+  .role { font-size: 1.15rem; color: var(--muted); margin: 0 0 2rem; }
+  .cta { display: flex; gap: 0.9rem; flex-wrap: wrap; }
+  .chips { margin-top: 1.6rem; }
+
+  .portrait-wrap { position: relative; }
+  .codebg {
+    position: absolute;
+    inset: -14px;
+    border-radius: 18px;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  .codebg pre {
+    margin: 0;
+    padding: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    line-height: 1.5;
+    color: var(--muted);
+    opacity: 0.5;
+  }
+  .portrait-img {
+    position: relative;
+    display: block;
+    width: 100%;
+    max-width: 360px;
+    height: auto;
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    object-position: 50% 14%;
+    border-radius: 14px;
+    border: 2px solid var(--accent);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+    margin-left: auto;
+  }
+
+  .block { padding: 3.5rem 0; }
+  .block h2 { font-size: 1.9rem; margin: 0 0 0.35rem; }
+  .lead { margin: 0 0 1.8rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.4rem; }
+
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 3rem; }
+  .post-row { display: flex; flex-direction: column; padding: 0.8rem 0; border-bottom: 1px solid var(--border); color: var(--text); }
+  .post-row:hover { text-decoration: none; }
+  .post-row:hover .post-title { color: var(--accent); }
+  .post-row .date { font-size: 0.75rem; }
+  .post-title { font-family: var(--font-display); font-size: 1.1rem; }
+
+  @media (max-width: 860px) {
+    .hero-grid, .split { grid-template-columns: 1fr; }
+    .portrait-wrap { order: -1; }
+    .codebg { inset: -8px; }
+    .portrait-img { margin: 0 auto; }
+  }
+</style>
+```
+
+Note: the About blurb summarizes facts already on the real About page (no invented claims). `featured` renders the grid; the grid `auto-fill` left-aligns gracefully whether there are 1 or 2 cards.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 3: Build to confirm the page renders and assets resolve**
+
+Run: `npm run build`
+Expected: build succeeds; no error about `portrait.jpg` or `<Image>`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/index.astro
+git commit -m "Rebuild home as multi-section landing (hero, featured, about/writing)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Writing index — wide card grid
+
+**Files:**
+- Modify: `src/pages/writing/index.astro` (full replacement)
+
+- [ ] **Step 1: Replace the page**
+
+Replace the entire contents of `src/pages/writing/index.astro` with:
+
+```astro
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostCard from '../../components/PostCard.astro';
+
+const posts = (await getCollection('writing', ({ data }) => !data.draft))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+---
+<BaseLayout title="Writing — Steven Timothy" wide>
+  <span class="section-rule"></span>
+  <h1>Writing</h1>
+  <p class="muted">Notes on software architecture, engineering standards, and ideas worth exploring.</p>
+  {posts.length === 0 ? (
+    <p class="muted">First posts are on the way.</p>
+  ) : (
+    <div class="grid">
+      {posts.map((p) => (
+        <PostCard href={`/writing/${p.id}`} title={p.data.title} date={p.data.date} summary={p.data.summary} tags={p.data.tags} />
+      ))}
+    </div>
+  )}
+</BaseLayout>
+
+<style>
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.4rem; margin-top: 1.5rem; }
+</style>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/writing/index.astro
+git commit -m "Writing index: wide container + card grid
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Projects index — wide grid
+
+**Files:**
+- Modify: `src/pages/projects/index.astro`
+
+- [ ] **Step 1: Add the `wide` prop, section rule, and update grid**
+
+Replace the `<BaseLayout ...>` open tag (line 9) so it opens with `wide` and a section rule, and update the `.grid` minmax. The full replacement for the page body + style:
+
+```astro
+<BaseLayout title="Projects — Steven Timothy" wide>
+  <span class="section-rule"></span>
+  <h1>Projects</h1>
+  <p class="muted">Systems I've designed and things I've built.</p>
+  {projects.length === 0 ? (
+    <p class="muted">Selected work is being written up — check back soon.</p>
+  ) : (
+    <div class="grid">
+      {projects.map((p) => (
+        <ProjectCard href={`/projects/${p.id}`} title={p.data.title} summary={p.data.summary} tags={p.data.tags} />
+      ))}
+    </div>
+  )}
+</BaseLayout>
+
+<style>
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.4rem; margin-top: 1.5rem; }
+</style>
+```
+
+Leave the frontmatter (imports + `projects` query) unchanged.
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/projects/index.astro
+git commit -m "Projects index: wide container + section rule
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: About + PostLayout section rules (narrow stays narrow)
+
+**Files:**
+- Modify: `src/pages/about.astro`
+- Modify: `src/layouts/PostLayout.astro`
+
+- [ ] **Step 1: Add a section rule to About**
+
+In `src/pages/about.astro`, insert a section rule immediately after the `<BaseLayout ...>` open tag and before `<h1>About</h1>` (line 5 area):
+
+```astro
+<BaseLayout title="About — Steven Timothy">
+  <span class="section-rule"></span>
+  <h1>About</h1>
+```
+
+Do **not** add `wide` — About body text stays in the narrow reading container. Leave all body copy unchanged.
+
+- [ ] **Step 2: Add a section rule to PostLayout**
+
+In `src/layouts/PostLayout.astro`, insert a section rule as the first child of `<article class="prose">`, before `<h1>{title}</h1>` (line 14 area):
+
+```astro
+  <article class="prose">
+    <span class="section-rule"></span>
+    <h1>{title}</h1>
+```
+
+Do **not** add `wide` — article reading column stays 720px. Leave date/tags/slot and styles unchanged.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/about.astro src/layouts/PostLayout.astro
+git commit -m "Add section rule to About and article header (reading width unchanged)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Unit tests stay green**
+
+Run: `npm test`
+Expected: PASS (the unchanged `theme.ts` tests).
+
+- [ ] **Step 2: Type-check the whole project**
+
+Run: `npx astro check`
+Expected: `0 errors, 0 warnings` (the `'z' is deprecated` *hints* are expected and not actionable).
+
+- [ ] **Step 3: Production build**
+
+Run: `npm run build`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Visual pass in preview**
+
+Run: `npm run preview`
+Then in a browser check, in BOTH light and dark (toggle in nav), at desktop width AND a ~375px mobile width:
+- Home: hero two-column on desktop → portrait stacks above text on mobile; CTAs work ("View my work" → /projects, "Get in touch" → mailto); featured grid; about/writing split stacks on mobile.
+- Writing: card grid, collapses to one column on mobile.
+- Projects: card grid with thumbnails.
+- About: narrow readable column, section rule present.
+- One writing post and one project page: 720px reading column preserved; nav/footer span wide.
+- Confirm no horizontal scrollbar at 375px and the sticky nav stays usable.
+
+- [ ] **Step 5: Confirm draft filtering and empty-section behavior**
+
+Verify featured/writing home sections self-hide when their queries return nothing (e.g. temporarily flip `featured: true` to `false` in `src/content/projects/this-website.md`, rebuild, confirm the Featured section disappears, then revert). Drafts must never appear.
+
+- [ ] **Step 6: Final summary commit (only if any verification fix was needed)**
+
+If steps 1–5 required a fix, commit it:
+
+```bash
+git add -A
+git commit -m "Fix issues found during final verification
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+If nothing needed fixing, skip this step.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** layout system (Task 1, 2) · home centerpiece (Task 6) · writing/projects index (Task 7, 8) · about (Task 9) · post layout narrow column (Task 2 default + Task 9) · nav/footer/components reskin (Task 3, 4, 5) · mobile (Task 6 media query + Task 10 step 4) · both themes via tokens (all tasks) · contact mailto (Task 6) · dropped progress bars (Task 4 uses tags only) · testing/verification (Task 10). All spec sections mapped.
+- **Type consistency:** `ProjectCard` props (`href,title,summary,tags`) and `PostCard` props (`href,title,date,summary,tags`) match their call sites in Tasks 6/7/8. `BaseLayout` `wide`/`bleed` booleans match usage. `.container-wide`, `.btn*`, `.card`, `.section-rule` defined in Task 1 before first use.
+- **No placeholders:** every code step contains complete content.
+```

--- a/docs/superpowers/specs/2026-06-14-portfolio-layout-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-14-portfolio-layout-redesign-design.md
@@ -1,0 +1,136 @@
+# Portfolio Layout Redesign — Design Spec
+
+**Date:** 2026-06-14
+**Branch:** `redesign/portfolio-landing-layout`
+**Status:** Approved (design); spec under review
+
+## Summary
+
+Redesign the portfolio to adopt a busier, multi-section "landing page" layout
+(inspired by a reference template the owner liked), rendered entirely in the
+existing **espresso + amber** theme with **serif (Georgia) headings** and the
+**ST monogram**. Both **light and dark** themes are retained, mobile-friendly
+throughout.
+
+This is a **presentation-layer redesign only**. Content collections, Zod schemas,
+the `getCollection`/`render(entry)` data flow, the theming mechanism
+(`theme.ts`, the inline anti-flash script, `data-theme`), and the build/deploy
+pipeline are all unchanged.
+
+## Goals
+
+- Richer, multi-section home page: hero with portrait + CTAs, a featured-work
+  card row, an About/Latest-writing split, footer.
+- Apply the new aesthetic site-wide (nav, buttons, cards, spacing).
+- Preserve comfortable long-form reading on article pages.
+- Keep both themes correct and the whole site mobile-friendly.
+
+## Non-goals (YAGNI)
+
+- Decorative progress bars on project cards (reference had them; dropped as noise).
+- A dedicated Contact page or `Contact` nav item.
+- A social-icon row in the nav.
+- Any change to content schemas, the drafts workflow, or the CI/deploy pipeline.
+- Any change to theme-resolution logic or its tests.
+
+## Theming
+
+No logic changes. The design uses only existing CSS custom properties from
+`global.css` (`--bg`, `--surface`, `--text`, `--muted`, `--border`, `--accent`,
+`--accent-soft`, `--code-bg`). The theme toggle, OS-preference default, and
+inline pre-paint `data-theme` script all stay as-is. Both light and dark must
+render correctly for every new element (buttons, cards, hero glow, code backdrop).
+
+## Layout system (the one structural change)
+
+Today everything lives in a single 720px `.container`. Introduce two widths:
+
+- **`.container-wide` (~1120px)** — nav, home sections, Writing/Projects listing
+  grids. The "busy landing" width.
+- **`.container` (720px, unchanged)** — article **body text** on writing posts
+  and project detail pages. Long-form reading stays narrow; only the chrome
+  around it widens.
+
+New shared styles added to `global.css` alongside existing tokens/utilities:
+
+- `.btn`, `.btn-primary` (amber fill), `.btn-ghost` (bordered) — CTA buttons.
+- `.card` — surface card with border, radius, hover lift + amber border.
+- `.section-rule` — short amber tick above section headings.
+- `.container-wide` — the wider centered container.
+
+Use design tokens only (no hardcoded colors) so both themes stay correct.
+
+## Page-by-page
+
+### Home (`src/pages/index.astro`) — centerpiece
+
+- **Sticky nav** (wide container): monogram + name left; Home / Writing /
+  Projects / About + theme toggle right. Translucent blurred background.
+- **Two-column hero**:
+  - Left: headline, role line, two CTAs, tag chips.
+    - "View my work" → `/projects`
+    - "Get in touch" → `mailto:steven.timothy265@gmail.com`
+  - Right: portrait (existing `src/assets/portrait.jpg`), amber border, sitting
+    over a faint **code backdrop with an amber glow**.
+- **Featured work**: 3-up `ProjectCard` grid (thumbnail, title, summary, tag
+  chips, "Read more →"). No progress bars. Section self-hides when no featured
+  projects (current behavior preserved).
+- **Bottom split**: About blurb (→ `/about`) | Latest writing (2 most-recent
+  non-draft posts → post pages, "All writing →"). Section self-hides when empty.
+- **Footer**: existing push-to-bottom footer.
+
+Data queries are the existing ones; home surfaces latest non-draft post(s) and
+up to two `featured` non-draft projects.
+
+### Writing & Projects index (`src/pages/{writing,projects}/index.astro`)
+
+- Widen to `.container-wide`.
+- Render entries as the new **card grid** (replacing today's plain list), using
+  the reskinned `PostCard` / `ProjectCard`.
+- Same `getCollection(...)` queries; drafts still filtered out.
+
+### About (`src/pages/about.astro`)
+
+- Keep content; reskin with new nav/footer chrome, section rule, buttons.
+- Body text stays at readable width.
+
+### Post & Project detail (`src/layouts/PostLayout.astro`)
+
+- New nav/footer chrome via `BaseLayout`.
+- **720px reading column preserved** for article body — the core readability win.
+- Buttons/cards available for a project's optional repo/link row.
+
+### Components
+
+- `Nav.astro`, `Footer.astro`, `PostCard.astro`, `ProjectCard.astro` — reskinned.
+- `BaseLayout.astro` — gains a way to opt into the wide container (e.g. a
+  `wide` prop) while defaulting to the narrow reading container for article pages.
+
+## Mobile-friendliness (required)
+
+- Hero collapses from two columns to a single column (text above portrait) on
+  narrow screens; headline uses fluid `clamp()` sizing.
+- Featured-work and listing card grids collapse to 1–2 columns via
+  `grid-template-columns: repeat(auto-fill, minmax(...))` or explicit breakpoints.
+- Bottom About/Latest-writing split stacks vertically on mobile.
+- Nav remains usable at small widths (links wrap or condense; tap targets stay
+  comfortable). Sticky nav must not crowd content on short viewports.
+- Verify at a representative mobile width (~375px) in addition to desktop.
+
+## Testing & verification
+
+- `theme.ts` unit tests unchanged and still pass (`npm test`).
+- `npm run build` succeeds.
+- `npx astro check` → 0 errors / 0 warnings (the usual non-actionable
+  `'z' is deprecated` hints are expected).
+- `npm run preview` eyeball pass: both themes, at desktop and ~375px mobile,
+  across Home, Writing, Projects, About, and one post + one project page.
+- Confirm drafts are still filtered everywhere and empty home sections self-hide.
+
+## Risks / watch-items
+
+- Keep the wide vs. narrow container boundary clear so article reading width is
+  never accidentally widened.
+- Code-backdrop hero must stay legible/contrast-safe in light mode (it is
+  decorative; ensure it never reduces text contrast).
+- Buttons and cards must use tokens so both themes pass contrast.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const links = [
 ];
 ---
 <footer class="site-footer">
-  <div class="container footer-inner">
+  <div class="container-wide footer-inner">
     <span class="muted mono">© {new Date().getFullYear()} Steven Timothy</span>
     <div class="footer-links">
       {links.map((l) => <a href={l.href}>{l.label}</a>)}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -30,7 +30,9 @@ const links = [
     z-index: 100;
     border-bottom: 1px solid var(--border);
     padding: 1rem 0;
+    background: var(--bg); /* fallback for browsers without color-mix */
     background: color-mix(in srgb, var(--bg) 85%, transparent);
+    -webkit-backdrop-filter: blur(8px);
     backdrop-filter: blur(8px);
   }
   .nav-inner { display: flex; align-items: center; justify-content: space-between; }

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -8,7 +8,7 @@ const links = [
 ];
 ---
 <nav class="site-nav">
-  <div class="container nav-inner">
+  <div class="container-wide nav-inner">
     <a class="brand" href="/" aria-label="Steven Timothy — home">
       <svg class="logo" width="34" height="34" viewBox="0 0 84 84" aria-hidden="true">
         <rect class="logo-tile" x="1" y="1" width="82" height="82" rx="17" />
@@ -30,7 +30,8 @@ const links = [
     z-index: 100;
     border-bottom: 1px solid var(--border);
     padding: 1rem 0;
-    background: var(--bg);
+    background: color-mix(in srgb, var(--bg) 85%, transparent);
+    backdrop-filter: blur(8px);
   }
   .nav-inner { display: flex; align-items: center; justify-content: space-between; }
   .brand { display: inline-flex; align-items: center; }

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -15,7 +15,7 @@ const dateStr = date.toLocaleDateString('en-US', { year: 'numeric', month: 'shor
     <h3>{title}</h3>
     <p class="summary">{summary}</p>
     <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>
-    <span class="more accent">Read more →</span>
+    <span class="more accent" aria-hidden="true">Read more →</span>
   </div>
 </a>
 

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -9,17 +9,22 @@ interface Props {
 const { href, title, date, summary, tags } = Astro.props;
 const dateStr = date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 ---
-<article class="post-card">
-  <a href={href}><h3>{title}</h3></a>
-  <p class="muted mono date">{dateStr}</p>
-  <p>{summary}</p>
-  <div>{tags.map((t) => <span class="chip">{t}</span>)}</div>
-</article>
+<a class="card post-card" href={href}>
+  <div class="card-body">
+    <p class="muted mono date">{dateStr}</p>
+    <h3>{title}</h3>
+    <p class="summary">{summary}</p>
+    <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>
+    <span class="more accent">Read more →</span>
+  </div>
+</a>
 
 <style>
-  .post-card { padding: 1.5rem 0; border-bottom: 1px solid var(--border); }
-  .post-card h3 { margin: 0 0 0.25rem; color: var(--text); }
-  .post-card a:hover h3 { color: var(--accent); }
-  .date { font-size: 0.8rem; margin: 0 0 0.5rem; }
-  .post-card p { margin: 0.25rem 0; }
+  .post-card { color: var(--text); }
+  .card-body { padding: 1.3rem 1.4rem 1.4rem; }
+  .date { font-size: 0.78rem; margin: 0 0 0.5rem; }
+  .post-card h3 { margin: 0 0 0.4rem; font-size: 1.2rem; }
+  .summary { margin: 0 0 0.9rem; color: var(--muted); font-size: 0.92rem; }
+  .tags { margin-bottom: 0.8rem; }
+  .more { font-size: 0.9rem; font-weight: 600; }
 </style>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -13,7 +13,7 @@ const { href, title, summary, tags } = Astro.props;
     <h3>{title}</h3>
     <p class="summary">{summary}</p>
     <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>
-    <span class="more accent">Read more &rarr;</span>
+    <span class="more accent" aria-hidden="true">Read more &rarr;</span>
   </div>
 </a>
 

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -7,23 +7,28 @@ interface Props {
 }
 const { href, title, summary, tags } = Astro.props;
 ---
-<a class="project-card" href={href}>
-  <h3>{title}</h3>
-  <p>{summary}</p>
-  <div>{tags.map((t) => <span class="chip">{t}</span>)}</div>
+<a class="card project-card" href={href}>
+  <div class="thumb" aria-hidden="true"></div>
+  <div class="card-body">
+    <h3>{title}</h3>
+    <p class="summary">{summary}</p>
+    <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>
+    <span class="more accent">Read more &rarr;</span>
+  </div>
 </a>
 
 <style>
-  .project-card {
-    display: block;
-    padding: 1.4rem;
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    background: var(--surface);
-    color: var(--text);
-    transition: transform 0.12s ease, border-color 0.12s ease;
+  .project-card { color: var(--text); }
+  .thumb { height: 140px; position: relative; background: linear-gradient(135deg, var(--accent-soft), var(--code-bg)); }
+  .thumb::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(300px 120px at 30% 10%, color-mix(in srgb, var(--accent) 18%, transparent), transparent);
   }
-  .project-card:hover { transform: translateY(-2px); border-color: var(--accent); text-decoration: none; }
-  .project-card h3 { margin: 0 0 0.4rem; }
-  .project-card p { margin: 0 0 0.6rem; color: var(--muted); }
+  .card-body { padding: 1.1rem 1.2rem 1.3rem; }
+  .card-body h3 { margin: 0 0 0.4rem; font-size: 1.15rem; }
+  .summary { margin: 0 0 0.9rem; color: var(--muted); font-size: 0.92rem; }
+  .tags { margin-bottom: 0.8rem; }
+  .more { font-size: 0.9rem; font-weight: 600; }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,8 +6,15 @@ import Footer from '../components/Footer.astro';
 interface Props {
   title: string;
   description?: string;
+  wide?: boolean;
+  bleed?: boolean;
 }
-const { title, description = 'Lead software engineer writing about how systems are built.' } = Astro.props;
+const {
+  title,
+  description = 'Lead software engineer writing about how systems are built.',
+  wide = false,
+  bleed = false,
+} = Astro.props;
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -32,10 +39,12 @@ const { title, description = 'Lead software engineer writing about how systems a
   </head>
   <body>
     <Nav />
-    <main>
-      <div class="container">
+    <main class:list={[{ bleed }]}>
+      {bleed ? (
         <slot />
-      </div>
+      ) : (
+        <div class={wide ? 'container-wide' : 'container'}><slot /></div>
+      )}
     </main>
     <Footer />
   </body>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,7 +6,9 @@ import Footer from '../components/Footer.astro';
 interface Props {
   title: string;
   description?: string;
+  /** Use the wide (~1120px) container. Ignored when `bleed` is true. */
   wide?: boolean;
+  /** Render the slot full-bleed (no container). Takes precedence over `wide`. */
   bleed?: boolean;
 }
 const {
@@ -39,7 +41,7 @@ const {
   </head>
   <body>
     <Nav />
-    <main class:list={[{ bleed }]}>
+    <main class:list={{ bleed }}>
       {bleed ? (
         <slot />
       ) : (

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -11,6 +11,7 @@ const dateStr = date.toLocaleDateString('en-US', { year: 'numeric', month: 'shor
 ---
 <BaseLayout title={title} description={summary}>
   <article class="prose">
+    <span class="section-rule"></span>
     <h1>{title}</h1>
     <p class="muted mono date">{dateStr}</p>
     <div class="tags">{tags.map((t) => <span class="chip">{t}</span>)}</div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 <BaseLayout title="About — Steven Timothy">
+  <span class="section-rule"></span>
   <h1>About</h1>
   <p>
     I'm Steven Timothy — a lead software engineer at NiCE, where I've been since 2023.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,39 +5,53 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import portrait from '../assets/portrait.jpg';
 
-const latest = (await getCollection('writing', ({ data }) => !data.draft))
+const latestPosts = (await getCollection('writing', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
-  .slice(0, 1)[0];
+  .slice(0, 2);
 
 const featured = (await getCollection('projects', ({ data }) => !data.draft && data.featured))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
   .slice(0, 2);
+
+const fmt = (d: Date) => d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
 ---
-<BaseLayout title="Steven Timothy — Lead Software Engineer">
+<BaseLayout title="Steven Timothy — Lead Software Engineer" bleed>
   <section class="hero">
-    <div class="hero-head">
-      <Image src={portrait} alt="Steven Timothy" width={360} height={540} loading="eager" class="avatar" />
-      <div class="hero-intro">
-        <h1>Steven Timothy</h1>
-        <p class="role">Lead Software Engineer <span class="mono accent">// systems &amp; architecture</span></p>
+    <div class="container-wide hero-grid">
+      <div class="hero-text">
+        <h1>Lead Software Engineer<br />&amp; Future Architect</h1>
+        <p class="role">Building reliable systems — and writing about how they're designed. <span class="mono accent">// systems &amp; architecture</span></p>
+        <div class="cta">
+          <a class="btn btn-primary" href="/projects">View my work</a>
+          <a class="btn btn-ghost" href="mailto:steven.timothy265@gmail.com">Get in touch</a>
+        </div>
+        <div class="chips">
+          <span class="chip">software architecture</span>
+          <span class="chip">distributed systems</span>
+          <span class="chip">platform</span>
+        </div>
       </div>
-    </div>
-    {latest && (
-      <a class="latest" href={`/writing/${latest.id}`}>
-        <span class="label mono">~ latest</span>
-        <span class="latest-title">{latest.data.title} →</span>
-      </a>
-    )}
-    <div class="chips">
-      <span class="chip">software architecture</span>
-      <span class="chip">distributed systems</span>
-      <span class="chip">platform</span>
+      <div class="portrait-wrap">
+        <div class="codebg" aria-hidden="true"><pre>export class Service &#123;
+  async handle(req) &#123;
+    const ctx = build(req);
+    return pipeline(ctx);
+  &#125;
+&#125;
+function pipeline(ctx) &#123;
+  for (const stage of stages)
+    ctx = stage(ctx);
+&#125;</pre></div>
+        <Image src={portrait} alt="Steven Timothy" width={360} height={450} loading="eager" class="portrait-img" />
+      </div>
     </div>
   </section>
 
   {featured.length > 0 && (
-    <section class="featured">
+    <section class="container-wide block">
+      <span class="section-rule"></span>
       <h2>Featured work</h2>
+      <p class="lead muted">A few projects that show how I think about systems.</p>
       <div class="grid">
         {featured.map((p) => (
           <ProjectCard href={`/projects/${p.id}`} title={p.data.title} summary={p.data.summary} tags={p.data.tags} />
@@ -45,38 +59,92 @@ const featured = (await getCollection('projects', ({ data }) => !data.draft && d
       </div>
     </section>
   )}
+
+  <section class="container-wide block">
+    <div class="split">
+      <div>
+        <span class="section-rule"></span>
+        <h2>About</h2>
+        <p class="muted">Lead software engineer focused on software architecture — how systems are shaped, why they're built the way they are, and how to keep them healthy as they grow.</p>
+        <p><a class="accent" href="/about">More about me →</a></p>
+      </div>
+      {latestPosts.length > 0 && (
+        <div>
+          <span class="section-rule"></span>
+          <h2>Latest writing</h2>
+          {latestPosts.map((p) => (
+            <a class="post-row" href={`/writing/${p.id}`}>
+              <span class="date muted mono">{fmt(p.data.date)}</span>
+              <span class="post-title">{p.data.title}</span>
+            </a>
+          ))}
+          <p style="margin-top:1rem"><a class="accent" href="/writing">All writing →</a></p>
+        </div>
+      )}
+    </div>
+  </section>
 </BaseLayout>
 
 <style>
-  .hero { padding: 2rem 0 1rem; }
-  /* Default (mobile / mid): photo stacked above the name, both left-aligned with the body */
-  .hero-head { display: flex; flex-direction: column; align-items: flex-start; gap: 1.1rem; }
-  .avatar {
-    width: 96px;
-    height: 96px;
-    border-radius: 50%;
+  .hero {
+    border-bottom: 1px solid var(--border);
+    background: radial-gradient(900px 380px at 78% 20%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 60%);
+  }
+  .hero-grid { display: grid; grid-template-columns: 1.05fr 0.85fr; gap: 3rem; align-items: center; padding: 4rem 0 3.5rem; }
+  .hero-text h1 { font-size: clamp(2.2rem, 5vw, 3.4rem); margin: 0 0 1rem; }
+  .role { font-size: 1.15rem; color: var(--muted); margin: 0 0 2rem; }
+  .cta { display: flex; gap: 0.9rem; flex-wrap: wrap; }
+  .chips { margin-top: 1.6rem; }
+
+  .portrait-wrap { position: relative; }
+  .codebg {
+    position: absolute;
+    inset: -14px;
+    border-radius: 18px;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    overflow: hidden;
+  }
+  .codebg pre {
+    margin: 0;
+    padding: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    line-height: 1.5;
+    color: var(--muted);
+    opacity: 0.5;
+  }
+  .portrait-img {
+    position: relative;
+    display: block;
+    width: 100%;
+    max-width: 360px;
+    height: auto;
+    aspect-ratio: 4 / 5;
     object-fit: cover;
     object-position: 50% 14%;
+    border-radius: 14px;
     border: 2px solid var(--accent);
-    flex: 0 0 auto;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.3);
+    margin-left: auto;
   }
-  .hero h1 { font-size: clamp(2.25rem, 6vw, 3.5rem); margin: 0; }
-  .role { font-size: 1.15rem; margin: 0.6rem 0 1.75rem; }
-  /* Wide screens: outdent the photo into the left gutter so the name lines up with the body */
-  @media (min-width: 1080px) {
-    .hero-head {
-      flex-direction: row;
-      align-items: center;
-      gap: 1.75rem;
-      margin-left: calc(-120px - 1.75rem);
-    }
-    .avatar { width: 120px; height: 120px; }
+
+  .block { padding: 3.5rem 0; }
+  .block h2 { font-size: 1.9rem; margin: 0 0 0.35rem; }
+  .lead { margin: 0 0 1.8rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.4rem; }
+
+  .split { display: grid; grid-template-columns: 1fr 1fr; gap: 3rem; }
+  .post-row { display: flex; flex-direction: column; padding: 0.8rem 0; border-bottom: 1px solid var(--border); color: var(--text); }
+  .post-row:hover { text-decoration: none; }
+  .post-row:hover .post-title { color: var(--accent); }
+  .post-row .date { font-size: 0.75rem; }
+  .post-title { font-family: var(--font-display); font-size: 1.1rem; }
+
+  @media (max-width: 860px) {
+    .hero-grid, .split { grid-template-columns: 1fr; }
+    .portrait-wrap { order: -1; }
+    .codebg { inset: -8px; }
+    .portrait-img { margin: 0 auto; }
   }
-  .latest { display: block; border-left: 3px solid var(--accent); padding: 0.5rem 0 0.5rem 1rem; margin-bottom: 1.5rem; color: var(--text); }
-  .latest:hover { text-decoration: none; }
-  .latest:hover .latest-title { color: var(--accent); }
-  .label { display: block; font-size: 0.75rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
-  .latest-title { font-family: var(--font-display); font-size: 1.25rem; }
-  .featured { margin-top: 3rem; }
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1.2rem; margin-top: 1.2rem; }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -89,6 +89,7 @@ function pipeline(ctx) &#123;
   .hero {
     border-bottom: 1px solid var(--border);
     background: radial-gradient(900px 380px at 78% 20%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 60%);
+    overflow: hidden; /* contain the .codebg negative-inset bleed; never reaches the hero edges */
   }
   .hero-grid { display: grid; grid-template-columns: 1.05fr 0.85fr; gap: 3rem; align-items: center; padding: 4rem 0 3.5rem; }
   .hero-text h1 { font-size: clamp(2.2rem, 5vw, 3.4rem); margin: 0 0 1rem; }

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -6,7 +6,8 @@ import ProjectCard from '../../components/ProjectCard.astro';
 const projects = (await getCollection('projects', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 ---
-<BaseLayout title="Projects — Steven Timothy">
+<BaseLayout title="Projects — Steven Timothy" wide>
+  <span class="section-rule"></span>
   <h1>Projects</h1>
   <p class="muted">Systems I've designed and things I've built.</p>
   {projects.length === 0 ? (
@@ -21,5 +22,5 @@ const projects = (await getCollection('projects', ({ data }) => !data.draft))
 </BaseLayout>
 
 <style>
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 1.2rem; margin-top: 1.5rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.4rem; margin-top: 1.5rem; }
 </style>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -6,14 +6,21 @@ import PostCard from '../../components/PostCard.astro';
 const posts = (await getCollection('writing', ({ data }) => !data.draft))
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 ---
-<BaseLayout title="Writing — Steven Timothy">
+<BaseLayout title="Writing — Steven Timothy" wide>
+  <span class="section-rule"></span>
   <h1>Writing</h1>
   <p class="muted">Notes on software architecture, engineering standards, and ideas worth exploring.</p>
   {posts.length === 0 ? (
     <p class="muted">First posts are on the way.</p>
   ) : (
-    posts.map((p) => (
-      <PostCard href={`/writing/${p.id}`} title={p.data.title} date={p.data.date} summary={p.data.summary} tags={p.data.tags} />
-    ))
+    <div class="grid">
+      {posts.map((p) => (
+        <PostCard href={`/writing/${p.id}`} title={p.data.title} date={p.data.date} summary={p.data.summary} tags={p.data.tags} />
+      ))}
+    </div>
   )}
 </BaseLayout>
+
+<style>
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1.4rem; margin-top: 1.5rem; }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,6 +8,7 @@
   --border: #e4dac9;
   --accent: #b9701a;        /* amber, darkened for light-bg contrast */
   --accent-soft: #f0e2cf;
+  --accent-fg: #2a1c0c;
   --code-bg: #efe7da;
 }
 
@@ -19,6 +20,7 @@
   --border: #322a20;
   --accent: #e0a05a;        /* amber */
   --accent-soft: #2a2118;
+  --accent-fg: #1c140a;
   --code-bg: #211b14;
 }
 
@@ -27,6 +29,7 @@
   --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --maxw: 720px;
+  --maxw-wide: 1120px;
   --space: 1.25rem;
 }
 
@@ -85,7 +88,7 @@ pre {
 code { font-family: var(--font-mono); font-size: 0.9em; }
 
 /* ---- Layout primitives (redesign) ---- */
-.container-wide { max-width: 1120px; margin: 0 auto; padding: 0 var(--space); }
+.container-wide { max-width: var(--maxw-wide); margin: 0 auto; padding: 0 var(--space); }
 
 main.bleed { padding: 0; }
 
@@ -100,7 +103,7 @@ main.bleed { padding: 0; }
   cursor: pointer;
 }
 .btn:hover { text-decoration: none; }
-.btn-primary { background: var(--accent); color: var(--bg); }
+.btn-primary { background: var(--accent); color: var(--accent-fg); }
 .btn-primary:hover { filter: brightness(1.06); }
 .btn-ghost { background: transparent; color: var(--text); border-color: var(--border); }
 .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,3 +83,37 @@ pre {
   font-size: 0.9rem;
 }
 code { font-family: var(--font-mono); font-size: 0.9em; }
+
+/* ---- Layout primitives (redesign) ---- */
+.container-wide { max-width: 1120px; margin: 0 auto; padding: 0 var(--space); }
+
+main.bleed { padding: 0; }
+
+.btn {
+  display: inline-block;
+  padding: 0.7rem 1.4rem;
+  border-radius: 10px;
+  font-family: var(--font-body);
+  font-size: 0.98rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.btn:hover { text-decoration: none; }
+.btn-primary { background: var(--accent); color: var(--bg); }
+.btn-primary:hover { filter: brightness(1.06); }
+.btn-ghost { background: transparent; color: var(--text); border-color: var(--border); }
+.btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+
+.card {
+  display: block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  color: var(--text);
+  transition: transform 0.15s ease, border-color 0.15s ease;
+}
+.card:hover { transform: translateY(-3px); border-color: var(--accent); text-decoration: none; }
+
+.section-rule { display: inline-block; width: 46px; height: 3px; background: var(--accent); border-radius: 2px; margin-bottom: 1.2rem; }


### PR DESCRIPTION
## Summary

Rebuilds the portfolio into a busier, multi-section landing layout (inspired by a reference template) rendered entirely in the existing **espresso + amber** theme — serif headings, ST monogram, both **light & dark** themes retained, mobile-friendly. Presentation-layer only: content collections, Zod schemas, the `getCollection`/`render` data flow, and the theming logic (`theme.ts`, inline anti-flash script) are untouched.

- **Layout system:** new `.container-wide` (~1120px) for nav/footer/home/listings; article + About pages keep the narrow 720px reading column via `BaseLayout` `wide`/`bleed` props.
- **Home:** full-bleed hero (headline + two CTAs + portrait over an amber-glow code backdrop) → Featured-work card grid → About / Latest-writing split. CTAs: "View my work" → `/projects`, "Get in touch" → `mailto:`.
- **Components:** reskinned `Nav` (translucent blurred sticky, with Safari + `color-mix` fallbacks) and `Footer`; `ProjectCard`/`PostCard` rebuilt as thumbnail/grid cards using tag chips (no fake progress bars); section rules added to Writing/Projects/About/PostLayout.
- **Tokens:** added `--maxw-wide` and an accessible `--accent-fg` (dark-on-amber text passes contrast in both themes).

Spec and plan: `docs/superpowers/specs/2026-06-14-portfolio-layout-redesign-design.md`, `docs/superpowers/plans/2026-06-14-portfolio-layout-redesign.md`.

## Test Plan

- [x] `npm test` — 5/5 pass (theme logic unchanged)
- [x] `npx astro check` — 0 errors / 0 warnings
- [x] `npm run build` — 7 pages built
- [x] Draft filtering intact; article reading width preserved (verified in built HTML)
- [ ] Visual pass in **both themes** at desktop + ~375px mobile (home hero stacks, grids collapse, About/writing split stacks, no horizontal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)