### PR TITLE
Fix missing horizontal gutter on mobile home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -91,7 +91,7 @@ function pipeline(ctx) &#123;
     background: radial-gradient(900px 380px at 78% 20%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 60%);
     overflow: hidden; /* contain the .codebg negative-inset bleed; never reaches the hero edges */
   }
-  .hero-grid { display: grid; grid-template-columns: 1.05fr 0.85fr; gap: 3rem; align-items: center; padding: 4rem 0 3.5rem; }
+  .hero-grid { display: grid; grid-template-columns: 1.05fr 0.85fr; gap: 3rem; align-items: center; padding-block: 4rem 3.5rem; }
   .hero-text h1 { font-size: clamp(2.2rem, 5vw, 3.4rem); margin: 0 0 1rem; }
   .role { font-size: 1.15rem; color: var(--muted); margin: 0 0 2rem; }
   .cta { display: flex; gap: 0.9rem; flex-wrap: wrap; }
@@ -130,7 +130,7 @@ function pipeline(ctx) &#123;
     margin-left: auto;
   }
 
-  .block { padding: 3.5rem 0; }
+  .block { padding-block: 3.5rem; }
   .block h2 { font-size: 1.9rem; margin: 0 0 0.35rem; }
   .lead { margin: 0 0 1.8rem; }
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.4rem; }


### PR DESCRIPTION
## Problem

On mobile, the home page content rendered **edge-to-edge** (zero horizontal gutter) while every other page kept the standard 20px gutter. Measured at 390px width:

- Writing page h1: `x:20 → right:370` ✓
- Home hero h1 / role / section headings: `x:0 → right:390` ✗

## Cause

The home page's hero and section blocks carried **both** `.container-wide` (`padding: 0 var(--space)`) **and** a scoped class that set a `padding` *shorthand* for vertical spacing — `.hero-grid { padding: 4rem 0 3.5rem }` and `.block { padding: 3.5rem 0 }`. The `0` in those shorthands wiped out the container's horizontal padding, and Astro's higher-specificity scoped selectors won. Other pages were unaffected because their container sits on a plain wrapper with no competing padding rule.

## Fix

Switched both rules to `padding-block` (vertical only) so they no longer clobber the horizontal gutter. Home content now measures a 20px gutter, matching the rest of the site, with no horizontal overflow.

## Verification

- `npm run build` — ✓ 7 pages built
- `npx astro check` — 0 errors / 0 warnings
- `npm test` — ✓ 5/5 pass
- Re-measured at 390px: all home content now `x:20 → right:370`

🤖 Generated with [Claude Code](https://claude.com/claude-code)