### PR TITLE
About voice rewrite + home banner regression fix

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -7,9 +7,9 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <p>
     I'm Steven Timothy — a lead software engineer at NiCE, where I've been since 2023.
     I hold an MS in Computer Science from the University of Utah and a BS in Computer
-    Science (with a minor in Spanish) from Utah State University. These days most of my
-    energy goes toward software architecture: how systems are shaped, why they're built
-    the way they are, and how to keep them healthy as they grow.
+    Science (with a minor in Spanish) from Utah State University. Right now I'm working to
+    learn more about software architecture — what it takes to be an architect, and what an
+    architect should be thinking about when designing a system.
   </p>
 
   <h2>What drives me</h2>
@@ -36,7 +36,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     happily play almost any board or card game with real strategy to it. Magic: The Gathering
     is a favorite, especially getting friends together for a game of Commander. I'm happiest
     outdoors, away from the noise of the city. And I'm drawn to medieval settings, dragons
-    and knights, and sci-fi — with a deep love of space and astronomy.
+    and knights, and sci-fi. Space interests me too — I like learning about it and getting
+    out the telescope to look at the stars and planets.
   </p>
 
   <p class="muted">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,7 +54,7 @@ function pipeline(ctx) &#123;
       <p class="lead muted">A few projects that show how I think about systems.</p>
       <div class="grid">
         {featured.map((p) => (
-          <ProjectCard href={`/projects/${p.id}`} title={p.data.title} summary={p.data.summary} tags={p.data.tags} />
+          <ProjectCard href={`/projects/${p.id}`} title={p.data.title} summary={p.data.summary} tags={p.data.tags} image={p.data.image} imageAlt={p.data.imageAlt} />
         ))}
       </div>
     </section>
@@ -65,7 +65,7 @@ function pipeline(ctx) &#123;
       <div>
         <span class="section-rule"></span>
         <h2>About</h2>
-        <p class="muted">Lead software engineer focused on software architecture — how systems are shaped, why they're built the way they are, and how to keep them healthy as they grow.</p>
+        <p class="muted">Lead software engineer working to grow into software architecture — what it takes to be an architect, and what an architect should be thinking about when designing a system.</p>
         <p><a class="accent" href="/about">More about me →</a></p>
       </div>
       {latestPosts.length > 0 && (


### PR DESCRIPTION
## Summary
- **About page:** rewrite the intro and "Outside of work" sections in Steven's voice (working toward software architecture; sci-fi and space/astronomy separated as distinct interests).
- **Home banner regression fix:** the featured `ProjectCard` on the home page wasn't passing `image`/`imageAlt`, so the project banner (added in #20) didn't render there. Now wired up to match the projects listing page.
- **Home about summary:** updated to match the new About-page voice (was still using the old "how systems are shaped…" phrasing).

## Test Plan
- [x] `npx astro check` — 0 errors / 0 warnings
- [x] `npm run build` — succeeds (7 pages)
- [x] Manual: home "Featured work" card shows the Astro banner; updated about summary renders; old phrasing removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)