### PR TITLE
Reword "This website" problem section to read less negative

### DIFF
--- a/src/content/projects/this-website.md
+++ b/src/content/projects/this-website.md
@@ -12,10 +12,12 @@ imageAlt: Astro logo
 
 ## The problem
 
-I didn't have a place that showed the work I've done — or where I stand on what makes
-code clean and well-architected. The times I tried, hand-building a polished portfolio
-from scratch cost more time than it was worth, and the moment I wanted to add something
-new, getting it to look right was enough friction that the site just fell out of date.
+I wanted a single home for the work I've done — and for where I stand on what makes
+code clean and well-architected. The real challenge isn't building a portfolio once;
+it's keeping one current. A site is only as useful as its last update, and a hand-built
+one tends to drift out of date the moment publishing something new means reworking the
+layout by hand. So the goal was to engineer for exactly that: a portfolio where staying
+current takes almost no effort.
 
 ## What I built
 


### PR DESCRIPTION
## Summary

Rewrites the **Problem** section of the `this-website` project so it reads less negative and no longer frames Steven as a developer who let the site fall out of date.

- Removes the "lazy" framing — cut "cost more time than it was worth" and "enough friction that the site just fell out of date."
- Reframes staleness as the engineering insight ("the real challenge isn't building a portfolio once; it's keeping one current") rather than a personal failing.
- Keeps Steven's voice and tone, and stays factually consistent with the rest of the page.

## Before

> I didn't have a place that showed the work I've done — or where I stand on what makes code clean and well-architected. The times I tried, hand-building a polished portfolio from scratch cost more time than it was worth, and the moment I wanted to add something new, getting it to look right was enough friction that the site just fell out of date.

## After

> I wanted a single home for the work I've done — and for where I stand on what makes code clean and well-architected. The real challenge isn't building a portfolio once; it's keeping one current. A site is only as useful as its last update, and a hand-built one tends to drift out of date the moment publishing something new means reworking the layout by hand. So the goal was to engineer for exactly that: a portfolio where staying current takes almost no effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)