### PR TITLE
Add 'Getting started with Claude' writing post

### DIFF
--- a/docs/superpowers/plans/2026-06-28-getting-started-with-claude.md
+++ b/docs/superpowers/plans/2026-06-28-getting-started-with-claude.md
@@ -1,0 +1,234 @@
+# Getting Started with Claude — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a beginner-friendly Writing post that explains classic chat vs. agentic AI and walks the reader through installing Claude Desktop / Claude Code across macOS, Linux, Windows, and WSL.
+
+**Architecture:** Content-as-data. The post is a single Markdown file under `src/content/writing/`, validated by the existing `writing` Zod schema and rendered by existing page/layout code. No code changes — publishing is purely adding the `.md` file. Verification is `npx astro check` (schema + types) and `npm run build` (renders).
+
+**Tech Stack:** Astro 6 content collections, Markdown, GitHub Pages deploy (unchanged).
+
+## Global Constraints
+
+- Never commit to `master`. Work happens on branch `writing/getting-started-with-claude` (already created).
+- File path: `src/content/writing/getting-started-with-claude.md`.
+- Frontmatter must satisfy the `writing` schema (`src/content.config.ts`): `title` (string), `date` (date), `summary` (string), `tags` (string[]), `draft` (boolean).
+- `draft: false`.
+- `date: 2026-06-28`.
+- Voice/format must match `src/content/writing/astro-github-pages-guide.md`: warm, direct, second person, command-by-command, fenced code blocks with language tags, `>` blockquote callouts for gotchas.
+- Factual anchors (verified 2026-06-28 against https://code.claude.com/docs/en/setup) — use these exact commands; do not invent others:
+  - macOS / Linux / WSL native install: `curl -fsSL https://claude.ai/install.sh | bash`
+  - Windows PowerShell native install: `irm https://claude.ai/install.ps1 | iex`
+  - npm alternative: `npm install -g @anthropic-ai/claude-code` (Node.js 18+)
+  - Verify: `claude --version`
+  - Launch in a project: `claude`
+  - Desktop downloads: macOS + Windows only (Linux uses CLI).
+  - Claude Code requires a paid plan (Pro/Max/Team/Enterprise); the free Claude.ai plan is chat-only.
+- Video hand-off: Nick Saraev, "Claude Code Full Course (2026)", https://youtu.be/QoQBzR1NIqI — plain Markdown link, no embed.
+- Out of scope: CLAUDE.md, skills, agents, MCP, hooks (mention only that they're deliberately left for later); deep tool comparisons; embedded video player.
+
+---
+
+### Task 1: Write the post and verify it builds
+
+**Files:**
+- Create: `src/content/writing/getting-started-with-claude.md`
+- Reference (read for voice, do not modify): `src/content/writing/astro-github-pages-guide.md`
+- Reference (schema, do not modify): `src/content.config.ts`
+
+**Interfaces:**
+- Consumes: the `writing` collection schema in `src/content.config.ts` (fields listed in Global Constraints).
+- Produces: a non-draft post that the Writing index and home page pick up automatically via `getCollection('writing')` — no other file references it by name.
+
+- [ ] **Step 1: Create the file with frontmatter**
+
+Create `src/content/writing/getting-started-with-claude.md` starting with exactly this frontmatter:
+
+```markdown
+---
+title: Getting started with Claude
+date: 2026-06-28
+summary: From classic chatbots to agentic AI — what the difference is, why it matters, and how to install Claude Desktop or Claude Code on macOS, Windows, WSL, and Linux so you can start using it in a real project.
+tags: [claude, ai, getting-started, tutorial]
+draft: false
+---
+```
+
+- [ ] **Step 2: Write the Intro section**
+
+Append after the frontmatter. 1–2 short paragraphs: what the reader will have by the end (an account plus a working agentic setup they can experiment with), who it's for (beginners — both developers and the curious non-developer, who is explicitly welcome to try the terminal side), and a light time expectation. Lead with the payoff. No heading needed for the intro (matches the existing guide, which opens with prose before the first `##`).
+
+- [ ] **Step 3: Write "Chat vs. agentic AI"**
+
+`## Chat vs. agentic AI`. Explain the core distinction in plain language: a classic LLM chat (ChatGPT, Claude.ai in the browser) *talks back* — you copy and paste between it and your work. Agentic AI *takes action* on your behalf: it reads and writes files, runs commands, and works through multi-step tasks directly inside your real project folder. Use one short analogy (e.g. advisor who tells you what to do vs. assistant who does it) and one concrete before/after contrast. Do not explain model internals. Include this callout near the end of the section:
+
+```markdown
+> **Claude isn't the only one.** This guide is about Claude, but agentic AI is a
+> broader shift — OpenAI's Codex and Google's Gemini CLI are agentic tools too. The
+> ideas here carry over; the setup steps below are Claude-specific.
+```
+
+- [ ] **Step 4: Write "Sign up"**
+
+`## Sign up`. Walk through creating an account at [claude.ai](https://claude.ai); the chat is free to start. Then the honest callout:
+
+```markdown
+> **Heads up on plans.** The free plan gives you the *chat*. The agentic tools below
+> — Claude Code — need a paid plan (Pro, Max, Team, or Enterprise). If you only want
+> to try the chat first, free is plenty; come back here when you're ready to let
+> Claude work inside your projects.
+```
+
+- [ ] **Step 5: Write "Two ways to go agentic"**
+
+`## Two ways to go agentic`. Frame the choice plainly so the reader knows which of the next two sections is theirs:
+- **Claude Desktop app** — a regular application with a window, no terminal required. Easiest start, and it has Claude Code built in. macOS and Windows.
+- **Claude Code (the CLI)** — runs in a terminal, maximum control, every platform including Linux and WSL.
+Make clear both reach the same agentic capabilities; the reader can pick one and switch later.
+
+- [ ] **Step 6: Write "Install the Desktop app"**
+
+`## Install the Desktop app`. Download from [claude.ai/download](https://claude.ai/download) (note: macOS and Windows; Linux users skip to the CLI section). Steps: download, install like any app, open it, sign in with the account from the Sign up step. One line that opening a project is just pointing it at a folder.
+
+- [ ] **Step 7: Write "Install Claude Code (the CLI)" with all four environments**
+
+`## Install Claude Code (the CLI)`. One short intro line, then a subsection per environment. Use exactly the verified commands from Global Constraints.
+
+`### macOS & Linux`
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+One line for Linux: package-manager installs (apt, dnf, apk) are also available if you prefer them.
+
+`### Windows`
+
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
+
+Note: run this in PowerShell; installing [Git for Windows](https://git-scm.com/downloads/win) is recommended so Claude Code can use its Bash tool.
+
+`### Windows + WSL`
+
+Explain: if you work in WSL (a Linux environment inside Windows), open your WSL terminal and run the macOS/Linux installer there — not PowerShell. You install and launch `claude` from inside WSL.
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Then a callout to help readers choose on Windows:
+
+```markdown
+> **Native Windows or WSL?** Use native Windows for Windows-native projects and
+> tools. Use WSL if your project relies on a Linux toolchain, or if you want Claude
+> Code's sandboxed command execution. Either works — pick where your code already lives.
+```
+
+Close the section with the npm alternative and verification:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+(one line: needs Node.js 18+), then:
+
+```bash
+claude --version
+```
+
+(one line: confirms the install worked).
+
+- [ ] **Step 8: Write "Start it in a project"**
+
+`## Start it in a project`. Define "project" as just a folder of files. CLI path: open a terminal in that folder and run:
+
+```bash
+claude
+```
+
+Note the first run opens a browser to log in. Desktop path: open the app and point it at the folder. One sentence that you're now talking to something that can act on the files in front of it.
+
+- [ ] **Step 9: Write "A few prompts to try"**
+
+`## A few prompts to try`. A short intro line, then 2–3 example prompts as a list (no step-by-step) that show the agentic difference, e.g.:
+- "Summarize what this project does."
+- "Add a README that explains how to run this."
+- "Find where logging is handled and explain it to me."
+One closing line encouraging the reader to just talk to it normally.
+
+- [ ] **Step 10: Write "Go deeper"**
+
+`## Go deeper`. Hand off to the course for learning the individual tools in depth:
+
+```markdown
+Once you're set up, the fastest way to learn what Claude can actually *do* is to
+watch someone drive it. Nick Saraev's [Claude Code Full Course](https://youtu.be/QoQBzR1NIqI)
+is a thorough, beginner-friendly walkthrough of the tools and how to use them.
+```
+
+Add one closing line noting that this guide intentionally skipped the deeper layers (project memory / `CLAUDE.md`, custom skills, and agents) — they're worth learning once the basics feel comfortable.
+
+- [ ] **Step 11: Run type/schema check**
+
+Run: `npx astro check`
+Expected: 0 errors, 0 warnings. (A number of `'z' is deprecated` *hints* are expected framework noise per CLAUDE.md — not failures.) If there are errors, they almost certainly mean the frontmatter doesn't match the schema; fix and re-run.
+
+- [ ] **Step 12: Run the production build**
+
+Run: `npm run build`
+Expected: build completes successfully and the output includes a generated page for the new writing slug (`getting-started-with-claude`).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/content/writing/getting-started-with-claude.md
+git commit -m "Add 'Getting started with Claude' writing post"
+```
+
+---
+
+### Task 2: Open the pull request
+
+**Files:** none (git/GitHub only).
+
+**Interfaces:**
+- Consumes: the committed post and the design/plan docs on branch `writing/getting-started-with-claude`.
+- Produces: a PR against `master`.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin writing/getting-started-with-claude
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base master --title "Add 'Getting started with Claude' writing post" --body "$(cat <<'EOF'
+## Summary
+- New Writing post: a beginner's guide to Claude — classic chat vs. agentic AI, signing up, and installing Claude Desktop / Claude Code across macOS, Windows, WSL, and Linux.
+- Ends with a few starter prompts and a hand-off to Nick Saraev's Claude Code Full Course for going deeper.
+- Intentionally scoped to basic setup: no CLAUDE.md / skills / agents.
+
+## Verification
+- `npx astro check` — 0 errors / 0 warnings (deprecation hints are framework noise).
+- `npm run build` — succeeds.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report the PR URL**
+
+Capture the URL printed by `gh pr create` and report it.
+
+---
+
+## Notes for the implementer
+
+- This is prose, not code — there is no unit-test cycle. The "tests" are `astro check` and `npm run build` in Task 1, steps 11–12. Do not add Vitest tests for content.
+- Do not delete anything in `scratchpad/` — this post was not generated from a scratchpad note, and the scratchpad workflow's review-before-delete rule applies regardless.
+- Keep paragraphs tight and skimmable; prefer short paragraphs and the existing guide's rhythm over long blocks.

--- a/docs/superpowers/specs/2026-06-28-getting-started-with-claude-design.md
+++ b/docs/superpowers/specs/2026-06-28-getting-started-with-claude-design.md
@@ -1,0 +1,105 @@
+# Getting Started with Claude — writing post design
+
+**Status:** approved design, pending spec review
+**Date:** 2026-06-28
+**Branch:** `writing/getting-started-with-claude`
+
+## Goal
+
+A new Writing post that takes a complete beginner from "I've heard of Claude" to a
+working agentic setup they can experiment with. The conceptual focus is the
+difference between a **classic LLM chat** (ChatGPT, Claude.ai) and **agentic AI**;
+the practical payoff is getting Claude Desktop or Claude Code installed and running
+in a real project across every major platform.
+
+## Audience
+
+Total beginners — both developers and non-developers. Non-coders are explicitly
+invited to try the agentic/terminal side, not steered away from it. Assume no prior
+Claude experience and minimal tooling knowledge; explain agentic AI from scratch.
+
+## Scope
+
+**In scope**
+- Explaining classic chat vs. agentic AI (the conceptual heart).
+- Signing up at claude.ai, with an honest note that agentic Claude Code requires a
+  paid plan (free tier is chat-only).
+- Installing the **Claude Desktop app** (GUI, macOS + Windows) — the no-terminal
+  on-ramp; note it has Claude Code built in.
+- Installing the **Claude Code CLI** across **macOS, Linux, Windows (native), and
+  Windows + WSL**.
+- Starting Claude in a project and 2–3 starter prompts that demonstrate the agentic
+  difference.
+- A hand-off link to Nick Saraev's "Claude Code Full Course (2026)" for going deeper.
+
+**Out of scope (YAGNI)**
+- CLAUDE.md, skills, agents, MCP, hooks — explicitly noted as deliberately skipped.
+- Two-track (coder vs. non-coder) document split — both options woven into one
+  narrative instead.
+- Embedded video player — plain link, consistent with existing posts.
+- Deep explanation of how agentic models work internally.
+
+## File & frontmatter
+
+- Path: `src/content/writing/getting-started-with-claude.md`
+- Frontmatter (validated by the `writing` Zod schema in `src/content.config.ts`):
+  - `title`: "Getting started with Claude"
+  - `date`: 2026-06-28
+  - `summary`: one line covering chat-vs-agentic plus installing Desktop & CLI on
+    Mac, Windows, WSL, and Linux.
+  - `tags`: `[claude, ai, getting-started, tutorial]`
+  - `draft`: false
+- Voice/format: match the existing `astro-github-pages-guide.md` — warm, direct,
+  command-by-command, fenced code blocks, blockquote callouts for gotchas.
+
+## Section outline (Approach A — concept-first)
+
+1. **Intro** — what the guide delivers, who it's for (coders and non-coders), a
+   short time promise. Lead with the payoff.
+2. **Chat vs. agentic AI** — classic LLM chat *talks back*; agentic AI *takes
+   action* (reads/writes files, runs commands, works across multiple steps inside
+   your real project). Short analogy plus a concrete contrast. No internals.
+3. **Sign up** — create an account at claude.ai; chat is free. Callout: Claude Code
+   (the agentic tool) needs a paid plan — Pro/Max/Team/Enterprise; the free tier is
+   chat-only.
+4. **Two ways to go agentic** — frame the choice: Claude Desktop app (GUI, no
+   terminal, easiest start, Claude Code built in) vs. Claude Code CLI (terminal,
+   maximum control). Both reach the same agentic capabilities.
+5. **Install — Desktop app** — download for macOS and Windows, launch, sign in.
+   Note Linux users use the CLI route below.
+6. **Install — Claude Code CLI** — cover all four environments:
+   - macOS: `curl -fsSL https://claude.ai/install.sh | bash`
+   - Linux: same `install.sh`; one-line note that apt/dnf/apk repos also exist.
+   - Windows native: PowerShell `irm https://claude.ai/install.ps1 | iex`; note Git
+     for Windows is recommended so the Bash tool works.
+   - Windows + WSL: run the `install.sh` *inside* the WSL terminal; install and
+     launch `claude` from WSL, not PowerShell; WSL adds sandboxing.
+   - Short "which on Windows?" callout: native for Windows-native projects, WSL for
+     Linux toolchains/sandboxing.
+   - Mention the npm alternative (`npm install -g @anthropic-ai/claude-code`,
+     Node 18+) and verifying with `claude --version`.
+7. **Start it in a project** — open a terminal in a project folder and run `claude`;
+   first run logs in via the browser. Desktop equivalent: open a folder in the app.
+   Brief note on what a "project" is (just a folder of files).
+8. **A few prompts to try** — 2–3 starter prompts that show the agentic difference,
+   e.g. "summarize what this project does", "add a README", "find where X is
+   handled". No step-by-step.
+9. **Go deeper** — hand off to Nick Saraev's Claude Code Full Course
+   (https://youtu.be/QoQBzR1NIqI) to learn the individual tools in depth. Note that
+   CLAUDE.md / skills / agents are intentionally left for later.
+
+## Factual anchors (verified against docs, 2026-06-28)
+
+- Native installer commands and the WSL/native Windows distinction come from
+  https://code.claude.com/docs/en/setup.
+- Claude Code requires a paid plan; the free Claude.ai plan does not include it.
+- The Desktop app can run Claude Code without a terminal (macOS + Windows downloads).
+- Do not invent facts beyond these and the existing verified sources.
+
+## Verification & delivery
+
+- `npx astro check` → expect 0 errors / 0 warnings (deprecation *hints* are
+  framework noise, per CLAUDE.md).
+- `npm run build` → must succeed.
+- Work happens on branch `writing/getting-started-with-claude` (never master).
+- Commit the post, push, open a PR against `master`.

--- a/docs/superpowers/specs/2026-06-28-getting-started-with-claude-design.md
+++ b/docs/superpowers/specs/2026-06-28-getting-started-with-claude-design.md
@@ -38,6 +38,8 @@ Claude experience and minimal tooling knowledge; explain agentic AI from scratch
   narrative instead.
 - Embedded video player — plain link, consistent with existing posts.
 - Deep explanation of how agentic models work internally.
+- Deep comparison of competing agentic tools — only a brief side note that they
+  exist.
 
 ## File & frontmatter
 
@@ -59,6 +61,8 @@ Claude experience and minimal tooling knowledge; explain agentic AI from scratch
 2. **Chat vs. agentic AI** — classic LLM chat *talks back*; agentic AI *takes
    action* (reads/writes files, runs commands, works across multiple steps inside
    your real project). Short analogy plus a concrete contrast. No internals.
+   Callout: Claude is the focus here, but it isn't the only agentic AI — others
+   exist (e.g. OpenAI's Codex, Google's Gemini CLI); the concepts transfer.
 3. **Sign up** — create an account at claude.ai; chat is free. Callout: Claude Code
    (the agentic tool) needs a paid plan — Pro/Max/Team/Enterprise; the free tier is
    chat-only.

--- a/src/content/writing/getting-started-with-claude.md
+++ b/src/content/writing/getting-started-with-claude.md
@@ -149,15 +149,18 @@ no terminal.
 
 ## A few prompts to try
 
-The fastest way to feel the difference is to ask for something real. From inside a
-project, try:
+The fastest way to feel the difference is to ask for something real. Point it at a
+folder of your own and try a few of these:
 
-- "Summarize what this project does."
-- "Add a README that explains how to run this."
-- "Find where logging is handled and explain it to me."
+- "Summarize what's in this folder."
+- "Take my rough notes in `notes.txt` and turn them into a clean, organized document."
+- "Rename these files so they're sorted by date, and group them into subfolders by topic."
+- "Walk me through what this project does and how the pieces fit together."
 
-Talk to it like you'd talk to a capable teammate — plain language is enough. Watch
-what it reads and changes, and you'll quickly get a sense of what it's good at.
+Whether your folder holds code, documents, photos, or a half-finished idea, the move
+is the same: talk to it like you'd talk to a capable teammate — plain language is
+enough. Watch what it reads and changes, and you'll quickly get a sense of what it's
+good at.
 
 ## Go deeper
 

--- a/src/content/writing/getting-started-with-claude.md
+++ b/src/content/writing/getting-started-with-claude.md
@@ -1,0 +1,171 @@
+---
+title: Getting started with Claude
+date: 2026-06-28
+summary: From classic chatbots to agentic AI — what the difference is, why it matters, and how to install Claude Desktop or Claude Code on macOS, Windows, WSL, and Linux so you can start using it in a real project.
+tags: [claude, ai, getting-started, tutorial]
+draft: false
+---
+
+If you've used ChatGPT or chatted with Claude in a browser, you've seen one half of
+what these tools can do. The other half — where the AI doesn't just answer you but
+actually *does the work*, in your files, on your machine — is a bigger leap than it
+sounds, and it's surprisingly easy to start using.
+
+This is a guide for getting there from zero. By the end you'll have an account, the
+tools installed, and Claude running inside a real project so you can try it for
+yourself. It's written for beginners, and that includes the curious non-developer —
+if you've never opened a terminal, you're exactly who the easy path is for. Plan on
+about fifteen minutes.
+
+## Chat vs. agentic AI
+
+The thing most people have used is a **classic chat**: ChatGPT, or Claude at
+[claude.ai](https://claude.ai). You type a question, it types back. It's brilliant
+at explaining, drafting, and brainstorming — but it lives in its own window. If it
+writes you some code or a document, *you* copy it out, paste it where it belongs, and
+run it yourself. The AI advises; you do the work.
+
+**Agentic AI** closes that loop. Instead of just talking back, it can take action on
+your behalf: read and write files, run commands, search a codebase, and work through
+a multi-step task — all inside your actual project folder. You ask for the outcome
+and it carries out the steps to get there.
+
+Think of it as the difference between an advisor and an assistant. A classic chat is
+the advisor on the phone telling you what to type. Agentic AI is the assistant
+sitting at your keyboard, doing it — and showing you what it changed. Ask a chatbot
+to "add a license file to my project" and you'll get text to copy. Ask an agentic
+tool the same thing and the file simply appears, written into the right place.
+
+> **Claude isn't the only one.** This guide is about Claude, but agentic AI is a
+> broader shift — OpenAI's Codex and Google's Gemini CLI are agentic tools too. The
+> ideas here carry over; the setup steps below are Claude-specific.
+
+## Sign up
+
+Everything starts with an account. Go to [claude.ai](https://claude.ai) and sign up —
+it's free, and the free account gets you the classic chat right away. Poke around,
+ask it something, get a feel for it.
+
+> **Heads up on plans.** The free plan gives you the *chat*. The agentic tools below —
+> Claude Code — need a paid plan (Pro, Max, Team, or Enterprise). If you just want to
+> try the chat first, free is plenty. Come back here when you're ready to let Claude
+> work inside your projects.
+
+## Two ways to go agentic
+
+There are two doors to the agentic side, and they lead to the same room. Pick whichever
+suits you — you can switch later.
+
+- **The Claude Desktop app** — a normal application with a window, no terminal
+  required. It's the easiest start, and it has Claude Code built right in. Available
+  for macOS and Windows.
+- **Claude Code (the command-line tool)** — runs in a terminal. A little more
+  hands-on, a lot of control, and it works everywhere, including Linux and WSL.
+
+Both reach the same capabilities. If "terminal" makes you nervous, start with the
+Desktop app. If you already live in a terminal, the CLI will feel right at home.
+
+## Install the Desktop app
+
+Head to [claude.ai/download](https://claude.ai/download) and grab the installer for
+your system — it's available for macOS and Windows. (On Linux, skip ahead to the CLI
+section below.)
+
+1. Download and install it the way you would any other app.
+2. Open it.
+3. Sign in with the account you made a moment ago.
+
+That's it. To work on a project, you point the app at a folder on your computer, and
+Claude can see and act on the files inside it.
+
+## Install Claude Code (the CLI)
+
+Prefer the terminal, or on Linux? Claude Code installs with a single command. Pick
+the one for your setup.
+
+### macOS & Linux
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+On Linux, package-manager installs (apt, dnf, apk) are also available if you'd rather
+go that route.
+
+### Windows
+
+In PowerShell:
+
+```powershell
+irm https://claude.ai/install.ps1 | iex
+```
+
+Installing [Git for Windows](https://git-scm.com/downloads/win) alongside it is
+recommended — it lets Claude Code use its Bash tool, which makes it more capable.
+
+### Windows + WSL
+
+WSL is a full Linux environment running inside Windows. If that's where your work
+lives, open your **WSL terminal** (not PowerShell) and run the macOS/Linux installer
+there. You install and launch `claude` from inside WSL.
+
+```bash
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+> **Native Windows or WSL?** Use native Windows for Windows-native projects and tools.
+> Use WSL if your project relies on a Linux toolchain, or if you want Claude Code's
+> sandboxed command execution. Either works — pick where your code already lives.
+
+Already have Node.js? You can install it through npm instead:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+That route needs Node.js 18 or newer. Whichever method you used, confirm it worked:
+
+```bash
+claude --version
+```
+
+A version number means you're ready.
+
+## Start it in a project
+
+A "project" is just a folder of files — your website, a script, some notes, anything.
+
+With the **CLI**, open a terminal in that folder and run:
+
+```bash
+claude
+```
+
+The first time, it'll open your browser to log in. After that, you're talking to
+something that can read and change the files right in front of it.
+
+With the **Desktop app**, open the app and point it at the same folder. Same result,
+no terminal.
+
+## A few prompts to try
+
+The fastest way to feel the difference is to ask for something real. From inside a
+project, try:
+
+- "Summarize what this project does."
+- "Add a README that explains how to run this."
+- "Find where logging is handled and explain it to me."
+
+Talk to it like you'd talk to a capable teammate — plain language is enough. Watch
+what it reads and changes, and you'll quickly get a sense of what it's good at.
+
+## Go deeper
+
+Once you're set up, the fastest way to learn what Claude can actually *do* is to watch
+someone drive it. Nick Saraev's [Claude Code Full Course](https://youtu.be/QoQBzR1NIqI)
+is a thorough, beginner-friendly walkthrough of the tools and how to use them.
+
+I've deliberately kept this guide to the basics — there are deeper layers worth
+learning later (project memory via a `CLAUDE.md` file, custom skills, and agents) once
+the fundamentals feel comfortable. For now, the best next step is simple: open one of
+your own projects and start asking.

--- a/src/content/writing/getting-started-with-claude.md
+++ b/src/content/writing/getting-started-with-claude.md
@@ -156,6 +156,7 @@ folder of your own and try a few of these:
 - "Take my rough notes in `notes.txt` and turn them into a clean, organized document."
 - "Rename these files so they're sorted by date, and group them into subfolders by topic."
 - "Walk me through what this project does and how the pieces fit together."
+- "Figure out the best way to turn these files into a single PDF, then go ahead and do it." — the real payoff: it researches *how*, then actually does it.
 
 Whether your folder holds code, documents, photos, or a half-finished idea, the move
 is the same: talk to it like you'd talk to a capable teammate — plain language is


### PR DESCRIPTION
## Summary
- New Writing post: a beginner's guide to Claude — classic chat vs. agentic AI, signing up, and installing Claude Desktop / Claude Code across macOS, Windows, WSL, and Linux.
- Ends with a few starter prompts and a hand-off to Nick Saraev's Claude Code Full Course for going deeper.
- Intentionally scoped to basic setup: no CLAUDE.md / skills / agents.

## Verification
- `npx astro check` — 0 errors / 0 warnings (deprecation hints are framework noise).
- `npm run build` — succeeds; generates `/writing/getting-started-with-claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)